### PR TITLE
Fix VITE_PUBLIC_URL environment variable

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -24,12 +24,13 @@ if (typeof window !== 'undefined') {
 }
 
 // Log warning if environment variables are missing
-if (!supabaseUrl || !supabaseAnonKey) {
-  ErrorHandler.log('Missing Supabase environment variables', {
+if (!supabaseUrl || !supabaseAnonKey || !publicUrl) {
+  ErrorHandler.log('Missing environment variables', {
     level: 'warn', // Change to warning instead of error
     context: {
       supabaseUrl: !!supabaseUrl,
       supabaseAnonKey: !!supabaseAnonKey,
+      publicUrl: !!publicUrl,
     },
   })
 }

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -127,8 +127,45 @@ export class ErrorHandler {
       }
     })
   }
+
+  /**
+   * Validate environment variables at startup and log errors for missing critical variables
+   */
+  static validateEnvVars() {
+    const requiredEnvVars = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY', 'VITE_PUBLIC_URL']
+
+    requiredEnvVars.forEach(varName => {
+      if (!import.meta.env[varName]) {
+        this.log(`Missing critical environment variable: ${varName}`, {
+          level: 'error',
+          context: {
+            type: 'Environment Configuration',
+          },
+        })
+      }
+    })
+  }
+
+  /**
+   * Define default values for environment variables in a central configuration module
+   */
+  static getEnvVar(varName: string, defaultValue: string): string {
+    const value = import.meta.env[varName] || defaultValue
+
+    if (value === defaultValue) {
+      this.log(`Using default value for environment variable: ${varName}`, {
+        level: 'warn',
+        context: {
+          type: 'Environment Configuration',
+        },
+      })
+    }
+
+    return value
+  }
 }
 
 // Initialize error handling when the module is imported
 ErrorHandler.initBrowserErrorHandling()
 ErrorHandler.safeApiCheck()
+ErrorHandler.validateEnvVars()


### PR DESCRIPTION
Update `src/lib/supabase/client.ts` to log a warning if `VITE_PUBLIC_URL` is missing.

* Modify the condition to check for `publicUrl` in addition to `supabaseUrl` and `supabaseAnonKey`.
* Add `publicUrl` to the context of the warning log.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GaryOcean428/Monkey-One/pull/237?shareId=4d0bcd78-cade-4495-83b1-a552f7095f5a).

## Summary by Sourcery

Enhance environment variable validation for Supabase client configuration by adding a check for the public URL

Bug Fixes:
- Improve error handling by checking for the missing VITE_PUBLIC_URL environment variable

Enhancements:
- Update error logging to include public URL status in the validation check